### PR TITLE
Microblaze's macro atomic_decrement bugfix

### DIFF
--- a/ports/sysdeps/microblaze/bits/atomic.h
+++ b/ports/sysdeps/microblaze/bits/atomic.h
@@ -196,17 +196,18 @@ typedef uintmax_t uatomic_max_t;
     int test;                                                                  \
     __asm __volatile (                                                         \
                 "   addc    r0, r0, r0;"                                       \
-                "1: lwx     %0, %3, r0;"                                       \
+                "1: lwx     %0, %4, r0;"                                       \
                 "   addic   %1, r0, 0;"                                        \
                 "   bnei    %1, 1b;"                                           \
-                "   addi    %0, %0, 1;"                                        \
-                "   swx     %0, %3, r0;"                                       \
+		"   addi    %3, %0, 1;"                                        \
+                "   swx     %3, %4, r0;"                                       \
                 "   addic   %1, r0, 0;"                                        \
                 "   bnei    %1, 1b;"                                           \
-                    : "=&r" (__val),                                           \
+                    : "=&r" (__tmp),                                           \
                     "=&r" (test),                                              \
-                    "=m" (*mem)                                                \
-                    : "r" (mem),                                               \
+		    "=m" (*mem),					       \
+		    "=&r" (__val)                                              \
+		    : "r" (mem),					       \
                     "m" (*mem)                                                 \
                     : "cc", "memory");                                         \
     __val;                                                                     \
@@ -231,20 +232,23 @@ typedef uintmax_t uatomic_max_t;
 
 #define __arch_atomic_decrement_val_32(mem)                                    \
   ({                                                                           \
-    __typeof (*(mem)) __val;                                                   \
+    __typeof (*(mem)) __tmp;     					       \
+    __typeof (*(mem)) __val;						       \
     int test;                                                                  \
     __asm __volatile (                                                         \
                 "   addc    r0, r0, r0;"                                       \
-                "1: lwx     %0, %3, r0;"                                       \
+                "1: lwx     %0, %4, r0;"                                       \
                 "   addic   %1, r0, 0;"                                        \
                 "   bnei    %1, 1b;"                                           \
-                "   rsubi   %0, %0, 1;"                                        \
-                "   swx     %0, %3, r0;"                                       \
+		"   addi    %1, r0, 1;"                                        \
+                "   rsub    %3, %1, %0;"				       \
+                "   swx     %3, %4, r0;"                                       \
                 "   addic   %1, r0, 0;"                                        \
                 "   bnei    %1, 1b;"                                           \
-                    : "=&r" (__val),                                           \
+                    : "=&r" (__tmp),                                           \
                     "=&r" (test),                                              \
-                    "=m" (*mem)                                                \
+		    "=m" (*mem),					       \
+		    "=&r" (__val)                                              \
                     : "r" (mem),                                               \
                     "m" (*mem)                                                 \
                     : "cc", "memory");                                         \

--- a/ports/sysdeps/microblaze/bits/atomic.h
+++ b/ports/sysdeps/microblaze/bits/atomic.h
@@ -192,7 +192,8 @@ typedef uintmax_t uatomic_max_t;
 
 #define __arch_atomic_increment_val_32(mem)                                    \
   ({                                                                           \
-    __typeof (*(mem)) __val;                                                   \
+    __typeof (*(mem)) __tmp;						       \
+    __typeof (*(mem)) __val;						       \
     int test;                                                                  \
     __asm __volatile (                                                         \
                 "   addc    r0, r0, r0;"                                       \


### PR DESCRIPTION
Fixed a bug in atomic.h that caused posix semaphores not to work properly. Modified increment macro to match the decrement format, too.

atomic_decrement is not a function widely used in libc because of many possible alternatives (compare_and_exchange, for example). It seems to be only used by nptl/sysdeps/unix/sysv/linux/sem_wait.c.

Anyway, this could fix other issues somewhere else in libc (didn't check them all).
